### PR TITLE
Fix nullpointer exception when changing config in-game and returning

### DIFF
--- a/BiomeTitlesUI.cs
+++ b/BiomeTitlesUI.cs
@@ -245,7 +245,10 @@ namespace BTitles
             if (Config.HideWhileBossIsAlive && bossIsAlive)
             {
                 // Hide titles if a boss is alive
-                _biomeTitle.Opacity = 0;
+                if (_biomeTitle != null)
+                {
+                    _biomeTitle.Opacity = 0;
+                }
 
                 if (_biomeSubTitle != null)
                 {
@@ -255,7 +258,10 @@ namespace BTitles
             else if (Config.HideWhileInventoryOpen && Main.playerInventory)
             {
                 // Hide titles if the inventory is open
-                _biomeTitle.Opacity = 0;
+                if (_biomeTitle != null)
+                {
+                    _biomeTitle.Opacity = 0;
+                }
 
                 if (_biomeSubTitle != null)
                 {


### PR DESCRIPTION
Sorry, the first pull-request wasn’t across forks, I was tired ;-)

When changing the mod config (specifically the position) while being in-game (I mean actively playing in a session) there’s a null-pointer exception

![286430187-1349f5d2-eae9-4635-86ac-7460ea086764](https://github.com/MGTro/BTitles-1.4.3/assets/1321285/b146156e-e800-45cb-aa31-5260145d4631)

This pull request should fix the issue. At least this specific null pointer exception.
